### PR TITLE
Fix typo "current"

### DIFF
--- a/snippets/csharp/System.Security/SecureString/AppendChar/xat.cs
+++ b/snippets/csharp/System.Security/SecureString/AppendChar/xat.cs
@@ -6,7 +6,7 @@ class Example
 {
     public static void Main()
     {
-       string msg = "The curent length of the SecureString object: {0}\n";
+       string msg = "The current length of the SecureString object: {0}\n";
        Console.WriteLine("1) Instantiate the SecureString object.");
        SecureString ss = new SecureString();
        Console.WriteLine(msg, ss.Length);
@@ -44,26 +44,26 @@ class Example
 }
 // The example displays the following output:
 //       1) Instantiate the SecureString object.
-//       The curent length of the SecureString object: 0
+//       The current length of the SecureString object: 0
 //
 //       2) Append 'a' to the value.
-//       The curent length of the SecureString object: 1
+//       The current length of the SecureString object: 1
 //
 //       3) Append 'X' to the value.
-//       The curent length of the SecureString object: 2
+//       The current length of the SecureString object: 2
 //
 //       4) Append 'c' to the value.
-//       The curent length of the SecureString object: 3
+//       The current length of the SecureString object: 3
 //
 //       5) Insert 'd' at the end of the value.
-//       The curent length of the SecureString object: 4
+//       The current length of the SecureString object: 4
 //
 //       6) Remove the last character ('d') from the value.
-//       The curent length of the SecureString object: 3
+//       The current length of the SecureString object: 3
 //
 //       7) Set the second character of the value to 'b'.
-//       The curent length of the SecureString object: 3
+//       The current length of the SecureString object: 3
 //
 //       8) Delete the value of the SecureString object:
-//       The curent length of the SecureString object: 0
+//       The current length of the SecureString object: 0
 //</snippet1>

--- a/snippets/visualbasic/VS_Snippets_CLR/SecureString.xAt/VB/xat.vb
+++ b/snippets/visualbasic/VS_Snippets_CLR/SecureString.xAt/VB/xat.vb
@@ -3,7 +3,7 @@ Imports System.Security
 
 Module Example
     Public Sub Main()
-       Dim msg As String = "The curent length of the SecureString object: {0}" + vbCrLf
+       Dim msg As String = "The current length of the SecureString object: {0}" + vbCrLf
        Console.WriteLine("1) Instantiate the SecureString object.")
        Dim ss As New SecureString()
        Console.WriteLine(msg, ss.Length)
@@ -41,26 +41,26 @@ Module Example
 End Module
 ' The example displays the following output:
 '       1) Instantiate the SecureString object.
-'       The curent length of the SecureString object: 0
+'       The current length of the SecureString object: 0
 '
 '       2) Append 'a' to the value.
-'       The curent length of the SecureString object: 1
+'       The current length of the SecureString object: 1
 '
 '       3) Append 'X' to the value.
-'       The curent length of the SecureString object: 2
+'       The current length of the SecureString object: 2
 '
 '       4) Append 'c' to the value.
-'       The curent length of the SecureString object: 3
+'       The current length of the SecureString object: 3
 '
 '       5) Insert 'd' at the end of the value.
-'       The curent length of the SecureString object: 4
+'       The current length of the SecureString object: 4
 '
 '       6) Remove the last character ('d') from the value.
-'       The curent length of the SecureString object: 3
+'       The current length of the SecureString object: 3
 '
 '       7) Set the second character of the value to 'b'.
-'       The curent length of the SecureString object: 3
+'       The current length of the SecureString object: 3
 '
 '       8) Delete the value of the SecureString object:
-'       The curent length of the SecureString object: 0
+'       The current length of the SecureString object: 0
 '</snippet1>


### PR DESCRIPTION
## Summary

Fixed the typo "curent" in `csharp/System.Security/SecureString/AppendChar/xat.cs` and `visualbasic/VS_Snippets_CLR/SecureString.xAt/VB/xat.vb`